### PR TITLE
Spam prevention for forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# pre:2.0.2
+## _unknown_
+1. [](#improved)
+   - add spam prevention to contact form
+
 # 2.0.1
 ## 28-01-2025
 1. [](#bugfix)

--- a/config/plugins/form.yaml
+++ b/config/plugins/form.yaml
@@ -1,0 +1,3 @@
+turnstile:
+  site_key: CF_SITE_KEY # via doppler
+  secret_key: CF_SECRET_KEY # via doppler

--- a/pages/10.über/01.kontakt/form.de.md
+++ b/pages/10.über/01.kontakt/form.de.md
@@ -52,6 +52,10 @@ form:
       validate:
         required: '1'
 
+    turnstile:
+      type: turnstile
+      theme: light
+
   buttons:
     submit:
       type: submit
@@ -62,6 +66,7 @@ form:
       value: Zurücksetzen
 
   process:
+    turnstile: true
     email:
       from: '{{ config.plugins.email.from }}'
       to:


### PR DESCRIPTION
add spam prevention to forms via Cloudflare turnstile
- doppler config
- contact form template